### PR TITLE
Make web scraping simpler

### DIFF
--- a/get_releases.py
+++ b/get_releases.py
@@ -4,7 +4,7 @@
 Get various Git-related releases for Git Rev News.
 
 Currently supports : Git, Git for Windows, libgit2, libgit2sharp, Github
-Enterprise, Gitlab, Bitbucket, GitKraken, Github Desktop, tig
+Enterprise, Gitlab, Bitbucket, GitKraken, Github Desktop, tig, Sourcetree
 """
 
 import argparse
@@ -267,6 +267,11 @@ RELEASES = {
                                     'pattern': r' - (.* \d{4})$',
                                     'fmt': '%A, %B %d, %Y'}),
     'Github Desktop': GithubTags('desktop/desktop', r'^release-(\d\.\d\.\d+)$'),
+    'Sourcetree': HtmlNestedPage('https://www.sourcetreeapp.com/download-archives',
+                                 pattern=r'(\d\.\d\.?\d*\.?\d*)',
+                                 parent=['tr'],
+                                 releases={'number': ['div'], 'link': ['small']},
+                                 date={'elt': ['td'], 'fmt': '%d-%b-%Y'}),
     'tig': HtmlNestedPage('https://public-inbox.org/git/?q=d%3A{:%Y%m%d}..+%5BANNOUNCE%5D tig'.format(DATE),
                           pattern=r'^\[ANNOUNCE\] tig-(.*)')
 }


### PR DESCRIPTION
Following up on #5, I've tried to make some improvements to the web scraping:

+ We no longer have to write entire classes for each web page source. Instead, you either use `HtmlFlatPage` or `HtmlNestedPage`. It means that we should be able to write or update a source with a few lines in RELEASES. It's still not as simple as changing a single regex, but I think that's a step in the right direction.
+ f52f82a is an example of that: adding releases for Sourcetree only takes 5 lines. Also adresses #6
+ The new classes seem to have solved #7 as well